### PR TITLE
Upload estate agent CSV

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,79 +1,12 @@
-<p align="center"><img src="https://res.cloudinary.com/dtfbvvkyp/image/upload/v1566331377/laravel-logolockup-cmyk-red.svg" width="400"></p>
+# Street Group
 
-<p align="center">
-<a href="https://travis-ci.org/laravel/framework"><img src="https://travis-ci.org/laravel/framework.svg" alt="Build Status"></a>
-<a href="https://packagist.org/packages/laravel/framework"><img src="https://poser.pugx.org/laravel/framework/d/total.svg" alt="Total Downloads"></a>
-<a href="https://packagist.org/packages/laravel/framework"><img src="https://poser.pugx.org/laravel/framework/v/stable.svg" alt="Latest Stable Version"></a>
-<a href="https://packagist.org/packages/laravel/framework"><img src="https://poser.pugx.org/laravel/framework/license.svg" alt="License"></a>
-</p>
+## Running
 
-## About Laravel
+```
+composer install
+php artisan serve
+```
 
-Laravel is a web application framework with expressive, elegant syntax. We believe development must be an enjoyable and creative experience to be truly fulfilling. Laravel takes the pain out of development by easing common tasks used in many web projects, such as:
+## Tests
 
-- [Simple, fast routing engine](https://laravel.com/docs/routing).
-- [Powerful dependency injection container](https://laravel.com/docs/container).
-- Multiple back-ends for [session](https://laravel.com/docs/session) and [cache](https://laravel.com/docs/cache) storage.
-- Expressive, intuitive [database ORM](https://laravel.com/docs/eloquent).
-- Database agnostic [schema migrations](https://laravel.com/docs/migrations).
-- [Robust background job processing](https://laravel.com/docs/queues).
-- [Real-time event broadcasting](https://laravel.com/docs/broadcasting).
-
-Laravel is accessible, powerful, and provides tools required for large, robust applications.
-
-## Learning Laravel
-
-Laravel has the most extensive and thorough [documentation](https://laravel.com/docs) and video tutorial library of all modern web application frameworks, making it a breeze to get started with the framework.
-
-If you don't feel like reading, [Laracasts](https://laracasts.com) can help. Laracasts contains over 1500 video tutorials on a range of topics including Laravel, modern PHP, unit testing, and JavaScript. Boost your skills by digging into our comprehensive video library.
-
-## Laravel Sponsors
-
-We would like to extend our thanks to the following sponsors for funding Laravel development. If you are interested in becoming a sponsor, please visit the Laravel [Patreon page](https://patreon.com/taylorotwell).
-
-- **[Vehikl](https://vehikl.com/)**
-- **[Tighten Co.](https://tighten.co)**
-- **[Kirschbaum Development Group](https://kirschbaumdevelopment.com)**
-- **[64 Robots](https://64robots.com)**
-- **[Cubet Techno Labs](https://cubettech.com)**
-- **[Cyber-Duck](https://cyber-duck.co.uk)**
-- **[Many](https://www.many.co.uk)**
-- **[Webdock, Fast VPS Hosting](https://www.webdock.io/en)**
-- **[DevSquad](https://devsquad.com)**
-- [UserInsights](https://userinsights.com)
-- [Fragrantica](https://www.fragrantica.com)
-- [SOFTonSOFA](https://softonsofa.com/)
-- [User10](https://user10.com)
-- [Soumettre.fr](https://soumettre.fr/)
-- [CodeBrisk](https://codebrisk.com)
-- [1Forge](https://1forge.com)
-- [TECPRESSO](https://tecpresso.co.jp/)
-- [Runtime Converter](http://runtimeconverter.com/)
-- [WebL'Agence](https://weblagence.com/)
-- [Invoice Ninja](https://www.invoiceninja.com)
-- [iMi digital](https://www.imi-digital.de/)
-- [Earthlink](https://www.earthlink.ro/)
-- [Steadfast Collective](https://steadfastcollective.com/)
-- [We Are The Robots Inc.](https://watr.mx/)
-- [Understand.io](https://www.understand.io/)
-- [Abdel Elrafa](https://abdelelrafa.com)
-- [Hyper Host](https://hyper.host)
-- [Appoly](https://www.appoly.co.uk)
-- [OP.GG](https://op.gg)
-- [云软科技](http://www.yunruan.ltd/)
-
-## Contributing
-
-Thank you for considering contributing to the Laravel framework! The contribution guide can be found in the [Laravel documentation](https://laravel.com/docs/contributions).
-
-## Code of Conduct
-
-In order to ensure that the Laravel community is welcoming to all, please review and abide by the [Code of Conduct](https://laravel.com/docs/contributions#code-of-conduct).
-
-## Security Vulnerabilities
-
-If you discover a security vulnerability within Laravel, please send an e-mail to Taylor Otwell via [taylor@laravel.com](mailto:taylor@laravel.com). All security vulnerabilities will be promptly addressed.
-
-## License
-
-The Laravel framework is open-sourced software licensed under the [MIT license](https://opensource.org/licenses/MIT).
+In order to run the tests `composer run tests`

--- a/app/Domain/Person/Factory/PersonFactoryInterface.php
+++ b/app/Domain/Person/Factory/PersonFactoryInterface.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\Person\Factory;
+
+interface PersonFactoryInterface
+{
+    public function supports(array $data): bool;
+
+    public function fromArray(array $data): array;
+}

--- a/app/Domain/Person/Factory/SinglePersonFactory.php
+++ b/app/Domain/Person/Factory/SinglePersonFactory.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\Person\Factory;
+
+use App\Domain\Person\InvalidPersonException;
+use App\Domain\Person\Person;
+
+class SinglePersonFactory implements PersonFactoryInterface
+{
+    public function supports(array $data): bool
+    {
+        return count($data) === 1;
+    }
+
+    /**
+     * @param array $data
+     * @return Person[]
+     * @throws InvalidPersonException
+     */
+    public function fromArray(array $data): array
+    {
+        return [new Person($data[0])];
+    }
+}

--- a/app/Domain/Person/Factory/TwoPersonFactory.php
+++ b/app/Domain/Person/Factory/TwoPersonFactory.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\Person\Factory;
+
+use App\Domain\Person\InvalidPersonException;
+use App\Domain\Person\Person;
+use App\Enum\TitleEnum;
+
+class TwoPersonFactory implements PersonFactoryInterface
+{
+    public function supports(array $data): bool
+    {
+        return count($data) === 2;
+    }
+
+    /**
+     * @param array $data
+     * @return Person[]
+     * @throws InvalidPersonException
+     */
+    public function fromArray(array $data): array
+    {
+        $results = [];
+
+        // Given an array of ['Dr', 'Mr John Smith'] we want to replace Mr with Dr and in the end return ['Dr John Smith', 'Mr John Smith']
+        if ($this->isJustATitle($data)) {
+            $personWithReplacedTitle = $this->replaceTitle($data);
+            $results[] = new Person($personWithReplacedTitle);
+        } else {
+            $results[] = new Person($data[0]);
+        }
+
+        $results[] = new Person($data[1]);
+
+        return $results;
+    }
+
+    private function replaceTitle(array $data): string
+    {
+        $name = explode(' ', $data[1]);
+
+        foreach (TitleEnum::getAll() as $title) {
+            if ($title === $name[0]) {
+                return str_replace($title, $data[0], $data[1]);
+            }
+        }
+
+        throw new \InvalidArgumentException();
+    }
+
+    private function isJustATitle(array $data): bool
+    {
+        return in_array($data[0], TitleEnum::getAll(), true);
+    }
+}

--- a/app/Domain/Person/InvalidPersonException.php
+++ b/app/Domain/Person/InvalidPersonException.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace App\Domain\Person;
+
+class InvalidPersonException extends \Exception
+{
+
+}

--- a/app/Domain/Person/PeopleCollection.php
+++ b/app/Domain/Person/PeopleCollection.php
@@ -1,0 +1,61 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\Person;
+
+class PeopleCollection
+{
+    private array $people = [];
+
+    private PersonMapper $mapper;
+
+    public function __construct(PersonMapper $mapper)
+    {
+        $this->mapper = $mapper;
+    }
+
+    public function fromCsv($csv): self
+    {
+        if (!is_resource($csv)) {
+            throw new \InvalidArgumentException('fromCSV expects a resource');
+        }
+
+        $people = [];
+
+        while (($data = fgetcsv($csv, 0, ',')) !== false) {
+            $splitPeople = $this->splitPeople($data);
+            $csvHeader = 'homeowner';
+
+            if ($data[0] !== $csvHeader) {
+                $people[] = $splitPeople;
+            }
+        }
+
+        $mappedPeople = $this->mapper->map($people);
+
+        foreach ($mappedPeople as $person) {
+            $this->people[] = $person;
+        }
+
+        return $this;
+    }
+
+    /**
+     * @return Person[]
+     */
+    public function toArray(): array
+    {
+        return $this->people;
+    }
+
+    public function flatten(): array
+    {
+        return array_map(fn (Person $person) => $person->toArray(), $this->toArray());
+    }
+
+    private function splitPeople(array $people): array
+    {
+        return preg_split('/ (and|&) /', $people[0]);
+    }
+}

--- a/app/Domain/Person/Person.php
+++ b/app/Domain/Person/Person.php
@@ -4,18 +4,10 @@ declare(strict_types=1);
 
 namespace App\Domain\Person;
 
+use App\Enum\TitleEnum;
+
 class Person
 {
-    private array $titles = [
-        'Dr',
-        'Mr',
-        'Ms',
-        'Mrs',
-        'Miss',
-        'Mister',
-        'Prof',
-    ];
-
     private string $title;
 
     private ?string $firstName = null;
@@ -60,7 +52,7 @@ class Person
 
     private function isTitleValid(array $data): bool
     {
-        return in_array($data[0], $this->titles, true);
+        return in_array($data[0], TitleEnum::getAll(), true);
     }
 
     private function hasRequiredFields(array $data): bool

--- a/app/Domain/Person/Person.php
+++ b/app/Domain/Person/Person.php
@@ -74,4 +74,21 @@ class Person
             'last_name' => $this->lastName,
         ];
     }
+
+    public function getFormattedName(): string
+    {
+        $name = $this->title;
+
+        if ($this->firstName) {
+            $name .= ' ' . $this->firstName;
+        }
+
+        if ($this->initial) {
+            $name .= ' ' . $this->initial;
+        }
+
+        $name .= ' ' . $this->lastName;
+
+        return $name;
+    }
 }

--- a/app/Domain/Person/Person.php
+++ b/app/Domain/Person/Person.php
@@ -1,0 +1,85 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\Person;
+
+class Person
+{
+    private array $titles = [
+        'Dr',
+        'Mr',
+        'Ms',
+        'Mrs',
+        'Miss',
+        'Mister',
+        'Prof',
+    ];
+
+    private string $title;
+
+    private ?string $firstName = null;
+
+    private ?string $initial = null;
+
+    private string $lastName;
+
+    public function __construct(string $data)
+    {
+        $data = explode(' ', $data);
+
+        if (!$this->hasRequiredFields($data)) {
+            throw new InvalidPersonException('Missing title');
+        }
+
+        if (!$this->isTitleValid($data)) {
+            throw new InvalidPersonException(sprintf('Invalid title of %s given', $data[0]));
+        }
+
+        if ($this->hasInitial($data)) {
+            $this->initial = $this->getFirstLetterOfString($data[1]);
+        }
+
+        if ($this->hasFirstName($data)) {
+            $this->firstName = $data[1];
+        }
+
+        $this->title = $data[0];
+        $this->lastName = end($data);
+    }
+
+    private function hasFirstName(array $data): bool
+    {
+        return count($data) > 2 && $data[1] !== $this->getFirstLetterOfString($data[1]);
+    }
+
+    private function hasInitial(array $data): bool
+    {
+        return count($data) > 2 && $data[1] === $this->getFirstLetterOfString($data[1]);
+    }
+
+    private function isTitleValid(array $data): bool
+    {
+        return in_array($data[0], $this->titles, true);
+    }
+
+    private function hasRequiredFields(array $data): bool
+    {
+        return count($data) > 1;
+    }
+
+    private function getFirstLetterOfString(string $string): string
+    {
+        return $string[0] . '.';
+    }
+
+    public function toArray(): array
+    {
+        return [
+            'title' => $this->title,
+            'first_name' => $this->firstName,
+            'initial' => $this->initial,
+            'last_name' => $this->lastName,
+        ];
+    }
+}

--- a/app/Domain/Person/Person.php
+++ b/app/Domain/Person/Person.php
@@ -42,12 +42,12 @@ class Person
 
     private function hasFirstName(array $data): bool
     {
-        return count($data) > 2 && $data[1] !== $this->getFirstLetterOfString($data[1]);
+        return count($data) > 2 && $data[1] !== $this->getFirstLetterOfString($data[1]) && strlen($data[1]) > 1;
     }
 
     private function hasInitial(array $data): bool
     {
-        return count($data) > 2 && $data[1] === $this->getFirstLetterOfString($data[1]);
+        return strlen($data[1]) === 1 || (count($data) > 2 && ($data[1] === $this->getFirstLetterOfString($data[1])));
     }
 
     private function isTitleValid(array $data): bool

--- a/app/Domain/Person/PersonMapper.php
+++ b/app/Domain/Person/PersonMapper.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\Person;
+
+use App\Domain\Person\Factory\PersonFactoryInterface;
+
+class PersonMapper
+{
+    /** @var PersonFactoryInterface[] */
+    private array $people;
+
+    public function __construct(array $people)
+    {
+        $this->people = $people;
+    }
+
+    public function map(array $data): array
+    {
+        $people = [];
+
+        foreach ($data as $datum) {
+            foreach ($this->people as $person) {
+                if ($person->supports($datum)) {
+                    $result = $person->fromArray($datum);
+
+                    foreach ($result as $item) {
+                        $people[] = $item;
+                    }
+                }
+            }
+        }
+
+        return $people;
+    }
+}

--- a/app/Enum/TitleEnum.php
+++ b/app/Enum/TitleEnum.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Enum;
+
+class TitleEnum
+{
+    public static function getAll(): array
+    {
+        return [
+            'Dr',
+            'Mr',
+            'Ms',
+            'Mrs',
+            'Miss',
+            'Mister',
+            'Prof',
+        ];
+    }
+}

--- a/app/Http/Controllers/CSVFileUploadController.php
+++ b/app/Http/Controllers/CSVFileUploadController.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Http\Controllers;
 
+use App\Domain\Person\PeopleCollection;
 use App\Http\Requests\UploadCSVRequest;
 use App\Service\FileSystem\CSVFile;
 
@@ -14,12 +15,15 @@ class CSVFileUploadController extends Controller
         return view('csv');
     }
 
-    public function upload(UploadCSVRequest $request, CSVFile $file)
+    public function upload(UploadCSVRequest $request, CSVFile $file, PeopleCollection $peopleCollection)
     {
         $data = $request->validated();
 
         $uploadedFileCsv = $file->upload($data['file'], 'people.csv');
 
-        return view('csv');
+        $people = $peopleCollection
+            ->fromCsv($uploadedFileCsv);
+
+        return view('csv', ['people' => $people]);
     }
 }

--- a/app/Http/Controllers/CSVFileUploadController.php
+++ b/app/Http/Controllers/CSVFileUploadController.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Controllers;
+
+use App\Http\Requests\UploadCSVRequest;
+use App\Service\FileSystem\CSVFile;
+
+class CSVFileUploadController extends Controller
+{
+    public function index()
+    {
+        return view('csv');
+    }
+
+    public function upload(UploadCSVRequest $request, CSVFile $file)
+    {
+        $data = $request->validated();
+
+        $uploadedFileCsv = $file->upload($data['file'], 'people.csv');
+
+        return view('csv');
+    }
+}

--- a/app/Http/Requests/UploadCSVRequest.php
+++ b/app/Http/Requests/UploadCSVRequest.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class UploadCSVRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    public function rules(): array
+    {
+        return [
+            'file' => ['required', 'mimes:csv,txt'],
+        ];
+    }
+}

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -2,6 +2,9 @@
 
 namespace App\Providers;
 
+use App\Domain\Person\Factory\SinglePersonFactory;
+use App\Domain\Person\Factory\TwoPersonFactory;
+use App\Domain\Person\PersonMapper;
 use Illuminate\Support\ServiceProvider;
 
 class AppServiceProvider extends ServiceProvider
@@ -23,6 +26,13 @@ class AppServiceProvider extends ServiceProvider
      */
     public function boot()
     {
-        //
+        $this->app->singleton(PersonMapper::class, static function () {
+            return new PersonMapper(
+                [
+                    new SinglePersonFactory(),
+                    new TwoPersonFactory(),
+                ]
+            );
+        });
     }
 }

--- a/app/Service/Filesystem/CSVFile.php
+++ b/app/Service/Filesystem/CSVFile.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Service\FileSystem;
+
+use Illuminate\Http\UploadedFile;
+use Illuminate\Contracts\Filesystem\Factory as Filesystem;
+
+class CSVFile implements FileInterface
+{
+    private Filesystem $storage;
+
+    public function __construct(Filesystem $storage)
+    {
+        $this->storage = $storage;
+    }
+
+    /**
+     * @param UploadedFile $file
+     * @param string $fileName
+     * @return null|resource
+     * @throws \Illuminate\Contracts\Filesystem\FileNotFoundException
+     */
+    public function upload(UploadedFile $file, string $fileName)
+    {
+        $this->storage->disk('local')->put($fileName, $file->get());
+
+        return $this->storage->disk('local')->readStream($fileName);
+    }
+}

--- a/app/Service/Filesystem/FileInterface.php
+++ b/app/Service/Filesystem/FileInterface.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Service\Filesystem;
+
+use Illuminate\Http\UploadedFile;
+
+interface FileInterface
+{
+    /**
+     * @param UploadedFile $file
+     * @param string $fileName
+     * @return null|resource
+     */
+    public function upload(UploadedFile $file, string $fileName);
+}

--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,7 @@
     ],
     "license": "MIT",
     "require": {
-        "php": "^7.2.5",
+        "php": "^7.4",
         "fideloper/proxy": "^4.2",
         "fruitcake/laravel-cors": "^1.0",
         "guzzlehttp/guzzle": "^6.3",

--- a/composer.json
+++ b/composer.json
@@ -58,6 +58,7 @@
         ],
         "post-create-project-cmd": [
             "@php artisan key:generate --ansi"
-        ]
+        ],
+        "tests": "./vendor/bin/phpunit"
     }
 }

--- a/resources/views/csv.blade.php
+++ b/resources/views/csv.blade.php
@@ -23,6 +23,16 @@
 
         <button type="submit">Submit</button>
     </form>
+
+    @isset($people)
+        <ul>
+            @foreach($people->toArray() as $person)
+                <li>{{ $person->getFormattedName() }}</li>
+            @endforeach
+        </ul>
+        {{ dd($people->flatten()) }}
+    @endisset
+
 </div>
 </body>
 </html>

--- a/resources/views/csv.blade.php
+++ b/resources/views/csv.blade.php
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html lang="{{ str_replace('_', '-', app()->getLocale()) }}">
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+</head>
+<body>
+<div>
+    @if ($errors->any())
+        <ul>
+            @foreach ($errors->all() as $error)
+                <li>{{ $error }}</li>
+            @endforeach
+        </ul>
+    @endif
+    <form role="form" method="POST" action="{{ route('csv-upload.upload') }}" enctype="multipart/form-data">
+        @csrf
+
+        <div>
+            <label for="file">File</label>
+            <input type="file" name="file" id="file">
+        </div>
+
+        <button type="submit">Submit</button>
+    </form>
+</div>
+</body>
+</html>

--- a/routes/web.php
+++ b/routes/web.php
@@ -1,6 +1,7 @@
 <?php
 
 use Illuminate\Support\Facades\Route;
+use App\Http\Controllers;
 
 /*
 |--------------------------------------------------------------------------
@@ -13,6 +14,5 @@ use Illuminate\Support\Facades\Route;
 |
 */
 
-Route::get('/', function () {
-    return view('welcome');
-});
+Route::get('/', [Controllers\CSVFileUploadController::class, 'index'])->name('csv-upload.index');
+Route::post('/', [Controllers\CSVFileUploadController::class, 'upload'])->name('csv-upload.upload');

--- a/tests/Unit/Domain/PeopleCollectionTest.php
+++ b/tests/Unit/Domain/PeopleCollectionTest.php
@@ -1,0 +1,76 @@
+<?php
+
+namespace Tests\Domain;
+
+use App\Domain\Person\Factory\SinglePersonFactory;
+use App\Domain\Person\Factory\TwoPersonFactory;
+use App\Domain\Person\PeopleCollection;
+use App\Domain\Person\PersonMapper;
+use Tests\TestCase;
+
+class PeopleCollectionTest extends TestCase
+{
+    public function testFromCsv_givenAValidCsv_peopleReturnedInCorrectFormat()
+    {
+        $fp = fopen(__DIR__ . '/../../stubs/people.csv', 'rb+');
+
+        $peopleCollection = $this->getPeopleCollection();
+
+        $collection = $peopleCollection->fromCsv($fp);
+
+        fclose($fp);
+
+        $this->assertEquals([
+            [
+                'title' => 'Mr',
+                'first_name' => 'John',
+                'initial' => null,
+                'last_name' => 'Smith',
+            ],
+            [
+                'title' => 'Mr',
+                'first_name' => 'Tom',
+                'initial' => null,
+                'last_name' => 'Staff',
+            ],
+            [
+                'title' => 'Mr',
+                'first_name' => 'John',
+                'initial' => null,
+                'last_name' => 'Doe',
+            ],
+            [
+                'title' => 'Dr',
+                'first_name' => 'Joe',
+                'initial' => null,
+                'last_name' => 'Bloggs',
+            ],
+            [
+                'title' => 'Mrs',
+                'first_name' => 'Joe',
+                'initial' => null,
+                'last_name' => 'Bloggs',
+            ],
+        ], $collection->flatten());
+    }
+
+    public function testFromCsv_givenANonResoruceType_invalidArgumentException()
+    {
+        $this->expectException(\InvalidArgumentException::class);
+
+        $peopleCollection = $this->getPeopleCollection();
+        $peopleCollection->fromCsv('not a resource');
+    }
+
+    private function getPeopleCollection()
+    {
+        return new PeopleCollection(
+            new PersonMapper(
+                [
+                    new SinglePersonFactory(),
+                    new TwoPersonFactory(),
+                ]
+            )
+        );
+    }
+}

--- a/tests/Unit/Domain/PersonTest.php
+++ b/tests/Unit/Domain/PersonTest.php
@@ -77,4 +77,21 @@ class PersonTest extends TestCase
 
         new Person('Mr');
     }
+
+    /**
+     * @dataProvider personProvider
+     */
+    public function testGetFormattedName_givenAPerson_formattedName(Person $person, string $expectedName)
+    {
+        $this->assertEquals($expectedName, $person->getFormattedName());
+    }
+
+    public function personProvider()
+    {
+        return [
+            [new Person('Mr John Smith'), 'Mr John Smith'],
+            [new Person('Mrs Jane McMaster'), 'Mrs Jane McMaster'],
+            [new Person('Dr P Gunn'), 'Dr P. Gunn'],
+        ];
+    }
 }

--- a/tests/Unit/Domain/PersonTest.php
+++ b/tests/Unit/Domain/PersonTest.php
@@ -1,0 +1,66 @@
+<?php
+
+namespace Tests\Domain;
+
+use App\Domain\Person\InvalidPersonException;
+use App\Domain\Person\Person;
+use Tests\TestCase;
+
+class PersonTest extends TestCase
+{
+    public function testPerson_givenPersonWithTitleFirstNameAndLastName_titleFirstNameAndLastNameSet()
+    {
+        $person = new Person('Mr John Smith');
+
+        $expected = [
+            'title' => 'Mr',
+            'initial' => null,
+            'first_name' => 'John',
+            'last_name' => 'Smith',
+        ];
+
+        $this->assertEquals($person->toArray(), $expected);
+    }
+
+    public function testPerson_givenPersonWithTitleAndLastName_titleAndLastNameSet()
+    {
+        $person = new Person('Mr Smith');
+
+        $expected = [
+            'title' => 'Mr',
+            'initial' => null,
+            'first_name' => null,
+            'last_name' => 'Smith',
+        ];
+
+        $this->assertEquals($person->toArray(), $expected);
+    }
+
+    public function testPerson_givenPersonWithTitleInitialAndLastName_titleInitialLastNameSet()
+    {
+        $person = new Person('Dr P. Smith');
+
+        $expected = [
+            'title' => 'Dr',
+            'initial' => 'P.',
+            'first_name' => null,
+            'last_name' => 'Smith',
+        ];
+
+        $this->assertEquals($person->toArray(), $expected);
+    }
+
+    public function testPerson_givenPersonWithInvalidTitle_invalidPersonException()
+    {
+        $this->expectException(InvalidPersonException::class);
+
+        new Person('Fake P. Smith');
+    }
+
+    public function testPerson_givenPersonJustATitle_invalidPersonException()
+    {
+        $this->expectException(InvalidPersonException::class);
+
+        new Person('Mr');
+    }
+}

--- a/tests/Unit/Domain/PersonTest.php
+++ b/tests/Unit/Domain/PersonTest.php
@@ -38,6 +38,20 @@ class PersonTest extends TestCase
 
     public function testPerson_givenPersonWithTitleInitialAndLastName_titleInitialLastNameSet()
     {
+        $person = new Person('Dr P Smith');
+
+        $expected = [
+            'title' => 'Dr',
+            'initial' => 'P.',
+            'first_name' => null,
+            'last_name' => 'Smith',
+        ];
+
+        $this->assertEquals($person->toArray(), $expected);
+    }
+
+    public function testPerson_givenPersonWithTitleInitialWithAFullStopAndLastName_titleInitialLastNameSet()
+    {
         $person = new Person('Dr P. Smith');
 
         $expected = [

--- a/tests/stubs/people.csv
+++ b/tests/stubs/people.csv
@@ -1,0 +1,4 @@
+homeowner,
+Mr John Smith,
+Mr Tom Staff and Mr John Doe,
+Dr & Mrs Joe Bloggs


### PR DESCRIPTION
This PR adds functionality to upload homeowner data and output this as an array.

Files are uploaded via the `CSVFile` class, this extends a `FileInterface`.
I could also just have used the `Storage` facade instead of passing `Illuminate\Contracts\Filesystem\Factory` via dependency injection

`Person.php` ([Link](https://github.com/jhornby/street-group/pull/1/files#diff-d99f3b8b165023a8838d978c3d8b79e6)) is where the logic to create a Person is stored, I think this encapsulates this logic nicely.

You can build a `Person` via either `PersonFactory` ([SinglePersonFactory](app/Domain/Person/Factory/SinglePersonFactory.php), [TwoPersonFactory](app/Domain/Person/Factory/TwoPersonFactory.php)), the responsibility of deciding which factory to use is contained within the `PersonMapper` ([Link](app/Domain/Person/PersonMapper.php)).

## What would I change given more time?

- Add more tests for `PersonMapper` and an end to end integration test.
- Handle exceptions, output errors to view & add errors to log files.
- Potentially think of ways to refactor `PersonMapper` to reduce the number of loops - although most likely this would only be if performance became an issue.
- If required `CSVFile` could be refactored to be more specific, for example if the system had to accept homeowners and landlords we could add `HomeownerCSVFile` & `LandlordCSVFile` both implementing `FileInterface`. At this point I'd most likely add a Data Transfer Object(DTO) so the return values would match and `PeopleCollection` wouldn't care what type of file is passed in. I decided not to do this in this PR because I've found premature abstraction can lead to overly complex code.